### PR TITLE
Fixed bug in multiple occurrences of & in query pairs resulted in a failed parse. Now multiple & are correctly ignored.

### DIFF
--- a/src/Arachne.Uri/Uri.fs
+++ b/src/Arachne.Uri/Uri.fs
@@ -631,8 +631,10 @@ type Query =
         let pairP =
             pairPartP .>>. opt(( skipChar '=') >>. ( pairPartV))
         
+        let skipAmp = (skipChar '&')
+
         let pairsP =
-            sepBy1 pairP (skipChar '&')
+            sepBy1 pairP (skipMany1 skipAmp)
 
         let pairF =
             function | (k, Some v) -> append k >> append "=" >> append v

--- a/src/Arachne.Uri/Uri.fs
+++ b/src/Arachne.Uri/Uri.fs
@@ -626,16 +626,16 @@ type Query =
             manySatisfy (int >> isEqualsOrAmpersand >> not)
 
         let pairPartP =
-            many1Satisfy (int >> isEqualsOrAmpersand >> not)
+            manySatisfy (int >> isEqualsOrAmpersand >> not)
 
         let pairP =
             pairPartP .>>. opt(( skipChar '=') >>. ( pairPartV))
         
-        let skipAmp = (skipChar '&')
+        let skipAmp = skipChar '&'
 
         let pairsP =
-            sepBy1 pairP (skipMany1 skipAmp)
-
+            sepBy1 pairP skipAmp
+        
         let pairF =
             function | (k, Some v) -> append k >> append "=" >> append v
                      | (k, None) -> append k
@@ -643,7 +643,7 @@ type Query =
         let pairsF =
             join pairF (append "&")
 
-        (fun (Query q) -> Parsing.tryParse pairsP q), (fun q -> Query (Formatting.format pairsF q))
+        (fun (Query q) -> if String.IsNullOrWhiteSpace q then None else Parsing.tryParse pairsP q), (fun q -> Query (Formatting.format pairsF q))
 
     (* Common *)
 

--- a/tests/Arachne.Uri.Tests/Types.Tests.fs
+++ b/tests/Arachne.Uri.Tests/Types.Tests.fs
@@ -176,3 +176,10 @@ let ``Query Pairs with no query parameters``() =
     let query = Query.Query("")
     let queryPairs = query |> fst Query.Pairs_
     Assert.AreEqual(expectedResult, queryPairs)
+
+[<Test>]
+let ``Query Pairs with more than 1 & can be parsed``() =
+    let expectedResult = Some ["param", Some("exists");"param1", Some("alsoexists")]
+    let query = Query.Query("param=exists&&param1=alsoexists")
+    let queryPairs = query |> fst Query.Pairs_
+    Assert.AreEqual(expectedResult, queryPairs)

--- a/tests/Arachne.Uri.Tests/Types.Tests.fs
+++ b/tests/Arachne.Uri.Tests/Types.Tests.fs
@@ -179,7 +179,7 @@ let ``Query Pairs with no query parameters``() =
 
 [<Test>]
 let ``Query Pairs with more than 1 & can be parsed``() =
-    let expectedResult = Some ["param", Some("exists");"param1", Some("alsoexists")]
+    let expectedResult = Some ["param", Some("exists"); "", None; "param1", Some("alsoexists")]
     let query = Query.Query("param=exists&&param1=alsoexists")
     let queryPairs = query |> fst Query.Pairs_
     Assert.AreEqual(expectedResult, queryPairs)


### PR DESCRIPTION
Also included a test.