### PR TITLE
Handle formating in CultureInvariant manor

### DIFF
--- a/src/Arachne.Core/Core.fs
+++ b/src/Arachne.Core/Core.fs
@@ -72,12 +72,13 @@ module internal Mapping =
 [<AutoOpen>]
 module internal Helpers =
 
+    open System.Globalization
 
     let append (s: string) (b: StringBuilder) =
         b.Append s
 
     let appendf1 (s: string) (v1: obj) (b: StringBuilder) =
-        b.AppendFormat (s, v1)
+        b.AppendFormat (CultureInfo.InvariantCulture, s, v1)
 
     let appendf2 (s: string) (v1: obj) (v2: obj) (b: StringBuilder) =
         b.AppendFormat (s, v1, v2)

--- a/tests/Arachne.Core.Tests/Prelude.fs
+++ b/tests/Arachne.Core.Tests/Prelude.fs
@@ -2,12 +2,26 @@
 module Arachne.Core.Tests.Prelude
 
 open Swensen.Unquote.Assertions
+open System.Globalization
+open System.Threading
 
 (* Helpers *)
 
 let inline (=?) a b = test <@ a = b @>
 
+let private culturesToTest = [
+    CultureInfo("en")
+    CultureInfo("de") ]
+
+let private useCulture c =
+    let current = Thread.CurrentThread.CurrentCulture
+    Thread.CurrentThread.CurrentCulture <- c
+    { new System.IDisposable with
+          member x.Dispose() = Thread.CurrentThread.CurrentCulture <- current }
+
 let roundTrip<'a when 'a: equality> (iso: ('a -> string) * (string -> 'a)) =
-    List.iter (fun (a, s) ->
-        (fst iso) a =? s
-        (snd iso) s =? a)
+        List.collect (fun p -> List.map (fun x -> x, p) culturesToTest)
+     >> List.iter (fun (c, (a, s)) ->
+            use __ = useCulture c
+            (fst iso) a =? s
+            (snd iso) s =? a)


### PR DESCRIPTION
I've run into the problem with my 'de-DE' setup.
`HttpVersion (HTTP 1.1)` is rendered as `HTTP/1,1`. Please note the comma.
Other broken parts are `Accept`, `AcceptCharset`, `AcceptEncoding`, and `AcceptLanguage`.

This brings problems to the Freya users when the app is running on setups where the decimal separator is not `.`.